### PR TITLE
The injection property should be limited to a finite segment of the natural numbers

### DIFF
--- a/hulls.v
+++ b/hulls.v
@@ -339,6 +339,11 @@ Hint Unfold distinct.
 Lemma distinct_spec : forall a b c, distinctb a b c = true -> distinct a b c.
 Proof. intros. unfold distinctb in *. flatten H. unfold distinct. auto. Qed.
 
+  Definition sym_triangle (t : Triangle.t) :=
+    match t with
+      [a, b, c] => [c, b, a]
+    end.
+  
 Fixpoint refute' (worklist : list Triangle.t) (problem : TS.t) :=
   match worklist with
       | nil => false
@@ -351,6 +356,21 @@ Fixpoint refute' (worklist : list Triangle.t) (problem : TS.t) :=
         else refute' wl problem
   end.
 
+Lemma refute'_step worklist problem : refute' worklist problem =
+  match worklist with
+      | nil => false
+      | [m,n,p]::wl =>
+        if distinctb m n p then
+          if inconsistent problem then true
+          else if negb (refute' wl (sat145 (TS.add [m,n,p] problem) 1000))
+               then false
+               else refute' wl (sat145 (TS.add [p,n,m] problem) 1000)
+        else refute' wl problem
+  end.
+Proof.
+ destruct worklist; reflexivity.
+Qed.
+
 Fixpoint enumerate len n : list (list nat) :=
   match n with
       O => match len with
@@ -361,7 +381,7 @@ Fixpoint enumerate len n : list (list nat) :=
       match len with
         | O => nil::nil
         | S l =>
-          List.map (fun e => 1::List.map (fun x => x + 1) e)
+          List.map (fun e => 0::List.map (fun x => x + 1) e)
                    (enumerate l p)++
                    List.map (fun e => List.map (fun x => x + 1) e)
                    (enumerate (S l) p)
@@ -379,7 +399,8 @@ Definition triplets_to_triangles :=
 Definition max_triangle t := match t with [a,b,c] => max (max a b) c end.
 Definition support ts := TS.fold (fun t => fun m => max m (max_triangle t)) ts 0. 
 
-Definition refute l := refute' (triplets_to_triangles (enumerate 3 (support l))) (sat145 l 1000).
+Definition refute l :=
+  refute' (triplets_to_triangles (enumerate 3 (S (support l)))) (sat145 l 1000).
 
 Definition canonical_problem := {{[1,2,3], [2,3,4], [1,5,2], [2,5,3], [4,3,5], [1,4,5]}}.
 (* 123 234 152 253 354 145 :
@@ -391,8 +412,7 @@ Definition canonical_problem := {{[1,2,3], [2,3,4], [1,5,2], [2,5,3], [4,3,5], [
         /    |
        1     4 
 *)
-Compute (refute canonical_problem).
-
+(* Compute (refute canonical_problem). *)
 
 Notation "x ∈ y" := (TS.In x y ) (at level 10).
 
@@ -400,9 +420,12 @@ Section FINAL.
   Variable A : Type.
   Variable oriented : A -> A -> A -> Prop.
   Variable inj : nat -> A.
-  Variable inj_inj : ∀ x y, inj x = inj y -> x = y.
+  Variable bound : nat.
+  Hypothesis inj_inj : ∀ x y, x < bound -> y < bound -> inj x = inj y -> x = y.
   Definition δ t := match t with [x, y, z] => oriented (inj x) (inj y) (inj z) end.
   Definition Δ := TS.For_all δ.
+  Definition b_pb ts := support ts < bound.
+
   Variable rule1 : forall a b c, δ [a, b, c] -> δ [b, c, a].
   Variable rule2 : forall a b c, δ [a, b, c] -> ¬δ [c, b, a].
   Variable rule3 : forall a b c, a ≠ b -> b ≠ c -> c ≠ a -> δ [a, b, c] ∨ δ [c, b, a].
@@ -411,19 +434,19 @@ Section FINAL.
   Variable hyps : TS.t.
   Hypothesis hyps_spec : Δ hyps.
   Variable ziel : Triangle.t.
+  Hypothesis hyps_b : b_pb (TS.add (sym_triangle ziel) hyps).
   Hypothesis ziel_not_degenerate : match ziel with [a, b, c] => distinct a b c end.
 
   Lemma Conseqs_imm_spec : forall ts ts', Conseqs_imm ts ts' -> Δ ts -> Δ ts'.
   Proof.
-    Hint Resolve rule1.
     intros ts ts' H HΔ x Hx.
-    assert (Conseq ts x) by intuition.
-    induction H0; [| | apply rule4 with d | apply rule5 with b d]; try intuition.
+    assert (csq : Conseq ts x) by intuition.
+    induction csq; [| | apply rule4 with d | apply rule5 with b d]; try intuition.
   Qed.
 
   Lemma Conseqs_spec : forall ts ts', Conseqs ts ts' -> Δ ts -> Δ ts'.
-    intros.
-    induction H; auto using (Conseqs_imm_spec ts ts').
+    intros ts ts' csq sp.
+    induction csq; auto using (Conseqs_imm_spec ts ts').
   Qed.
 
   Lemma sat145_spec : forall ts fuel, Δ ts -> Δ (sat145 ts fuel).
@@ -449,37 +472,155 @@ Section FINAL.
       [apply eq_is_eq in Heq; congruence | auto].
   Qed.
     
-  Lemma refute'_spec_axiom3: forall ts a b c (DIST: distinct a b c),
+  Lemma refute'_spec_axiom3 ts a b c (DIST: distinct a b c):
+      a < bound -> b < bound -> c < bound ->
       Δ ts -> ¬Δ (TS.add [a, b, c] ts) -> ¬Δ (TS.add [c, b, a] ts) -> False.
   Proof.
-    intros. unfold distinct in *. destruct DIST as [Ha [Hb Hc]].
+    intros. destruct DIST as [Ha [Hb Hc]].
     destruct (rule3 a b c); eauto using rule2, Δ_is_additive.
   Qed.
     
-  Lemma refute'_spec : forall wl ts, Δ ts -> refute' wl ts = true -> False.
+  Lemma refute'_spec : forall wl ts,
+     (forall t, In t wl ->
+      fst t < bound /\ fst (snd t) < bound /\ snd (snd t) < bound) ->
+     Δ ts -> refute' wl ts = true -> False.
   Proof.
-    intro. induction wl; intros ts H H0. 
-    + simpl in *. discriminate.
-    + destruct a as (x1, (x2, x3)). unfold refute' in H0.
+    induction wl as [ | a wl IHwl]; intros ts wlb H H0. 
+    + discriminate.
+    + destruct a as (x1, (x2, x3)). rewrite refute'_step in H0.
       flatten H0; [eauto using inconsistent_spec | | eauto].
       match goal with [H : negb _ = false |- _] => apply negb_false_iff in H end.
       eapply refute'_spec_axiom3 with (ts := ts) (a := x1) (b := x2) (c := x3);
         eauto; intros; eauto using sat145_spec, distinct_spec.
+      destruct (wlb [x1, x2, x3]) as [x1b [x2b x3b]];[left; reflexivity | exact x1b].
+      destruct (wlb [x1, x2, x3]) as [x1b [x2b x3b]];[left; reflexivity | exact x2b].
+      destruct (wlb [x1, x2, x3]) as [x1b [x2b x3b]];[left; reflexivity | exact x3b].
+      intros Delta; apply (IHwl (sat145 (TS.add [x1,x2,x3] ts) 1000)).
+      intros t twl; apply wlb; right; assumption.
+      apply sat145_spec; assumption.
+      assumption.
+      intros Delta; apply (IHwl (sat145 (TS.add [x3,x2,x1] ts) 1000)).
+      intros t twl; apply wlb; right; assumption.
+      apply sat145_spec; assumption.
+      assumption.
+      apply (IHwl ts); auto.
+     intros t twl; apply wlb; right; assumption.
   Qed.
 
-          
-  Lemma refute_spec : forall ts, Δ ts -> refute ts = true -> False.
+Lemma enumerate_lt : forall p n t l, In t l -> In l (enumerate p n) -> t < n.
+Proof.
+intros p n; revert p; induction n.
+ intros [ | p] t l intl.
+  intros [ql | []]; rewrite <- ql in intl; simpl in intl; contradiction.
+ simpl; contradiction.
+intros [ | p] t l intl; simpl. 
+ intros [ql | []]; rewrite <- ql in intl; simpl in intl; contradiction.
+intros ina; apply in_app_or in ina; destruct ina as [in1 | in2].
+ rewrite in_map_iff in in1; destruct in1 as [t' [qt' Pt']].
+ rewrite <- qt' in intl; simpl in intl; destruct intl as [t1 | tt'].
+  omega.
+ rewrite in_map_iff in tt'; destruct tt' as [x [qx inx]].
+ assert (IHn' := IHn _ _ _ inx Pt'); omega.
+rewrite in_map_iff in in2; destruct in2 as [t' [qt' Pt']].
+rewrite <- qt' in intl; rewrite in_map_iff in intl.
+destruct intl as [x [qx inx]].
+assert (IHn' := IHn _ _ _ inx Pt'); omega.
+Qed.
+
+Lemma support_spec1 n ts :
+  (forall t,
+     TS.mem t ts = true -> fst t <= n /\ fst (snd t) <= n /\ snd (snd t) <= n) ->
+  support ts <= n.
+Proof.
+unfold support; rewrite TS.fold_spec; intros cts.
+assert (cts' : forall t, existsb (SetProps.FM.eqb t) (TS.elements ts) = true ->
+           fst t <= n /\ fst (snd t) <= n /\ snd (snd t) <= n).
+ now intros t; rewrite <- SetProps.FM.elements_b; apply cts.
+revert cts'; clear cts.
+assert (nge0 : 0 <= n) by omega.
+revert nge0; generalize 0.
+induction (TS.elements ts) as [ | e l IHl]; simpl; intros p pn cts.
+ assumption.
+assert (max_n : max p (max_triangle e) <= n).
+ apply Max.max_lub;[assumption | ].
+ destruct (cts e) as [an [bn cn]].
+  unfold SetProps.FM.eqb; destruct (TS.E.eq_dec e e) as [ _ | n0];[reflexivity | ].
+  case n0; reflexivity.
+ unfold max_triangle; destruct e as [a [b c]].
+ apply Max.max_lub;[apply Max.max_lub | ]; assumption.
+assert (cts' : forall t, existsb (SetProps.FM.eqb t) l = true ->
+         fst t <= n /\ fst (snd t) <= n /\ snd (snd t) <= n).
+ intros t ext; apply cts; rewrite orb_comm, ext; reflexivity.
+clear cts; apply IHl; assumption.
+Qed.
+
+
+Lemma support_spec2 ts : forall t, TS.mem t ts = true -> 
+  fst t <= support ts /\ fst (snd t) <= support ts /\ snd (snd t) <= support ts.
+unfold support.
+intros t; rewrite TS.fold_spec, SetProps.FM.elements_b.
+assert (fold_max : forall l n, n <= fold_left (fun a e => max a (max_triangle e)) l n).
+ induction l as [ | a l IHl]; intros n.
+  now apply le_n. 
+ simpl; apply le_trans with (max n (max_triangle a)).
+  now apply Max.le_max_l. 
+ now apply IHl.
+generalize 0; induction (TS.elements ts) as [ | a l IHl].
+ intros n h; discriminate h.
+simpl; intros n exal.
+apply orb_prop in exal; destruct exal as [ta | it].
+ repeat apply conj; 
+   (apply le_trans with (max n (max_triangle a));
+    [unfold SetProps.FM.eqb in ta;
+   destruct (TS.E.eq_dec t a) as [ta' | _];
+      [rewrite ta'; apply le_trans with (2:= (Max.le_max_r _ _));
+        unfold max_triangle; destruct a as [e1 [e2 e3]] | discriminate] | apply fold_max]).
+   now apply le_trans with (2 := Max.le_max_l _ _), Max.le_max_l.
+  now apply le_trans with (2 := Max.le_max_l _ _), Max.le_max_r.
+ now apply Max.le_max_r.
+apply IHl; assumption.
+Qed.
+
+Lemma enumerate_len p n :
+  forall t, In t (enumerate p n) -> length t = p.
+revert p; induction n as [|n IHn].
+ simpl; intros [ | p]; simpl.
+  intros t' [nilt | []]; rewrite <- nilt; reflexivity.
+ contradiction.
+simpl; intros [ | p] t; simpl.
+ intros [nilt | []]; rewrite <- nilt; reflexivity.
+intros intl; apply in_app_or in intl; destruct intl as [intl | intl];
+rewrite in_map_iff in intl; destruct intl as [x [qx inx]]; rewrite <- qx;
+apply IHn in inx; simpl; rewrite map_length; auto.
+Qed.
+
+Lemma b_ps_enum ts :
+ b_pb ts -> forall t, In t (triplets_to_triangles (enumerate 3 (S (support ts)))) ->
+     fst t < bound /\ fst (snd t) < bound /\ snd (snd t) < bound.
+Proof.
+intros hb t int.
+generalize (enumerate_lt 3 (S (support ts))); revert t int.
+generalize (enumerate_len 3 (S (support ts))).
+induction (enumerate 3 (S (support ts))) as [ | t1 ts' Ih].
+ simpl; contradiction.
+simpl; intros len t; generalize (len t1 (or_introl (refl_equal _))).
+destruct t1 as [ | a [|b [ |c [ | d]]]]; try discriminate.
+intros _ [tabc | tts'] ils.
+ repeat apply conj; apply lt_le_trans with (2 := hb), ils with (l:=(a::b::c::nil)); 
+  try (rewrite <- tabc; simpl; tauto) || tauto.
+apply Ih in tts'.
+  intros; exact tts'.
+ intros t' int'; apply len; right; assumption.
+intros t' l int' inl; apply ils with l ; tauto.
+Qed.
+
+  Lemma refute_spec : forall ts, b_pb ts -> Δ ts -> refute ts = true -> False.
   Proof.
-    intros. unfold refute in *. eauto using refute'_spec, sat145_spec.
-    Grab Existential Variables.
-    exact nil.
+    intros ts bts Delta; unfold refute.
+    apply refute'_spec;[ | apply sat145_spec;assumption].
+    apply b_ps_enum; exact bts.
   Qed.    
 
-  Definition sym_triangle (t : Triangle.t) :=
-    match t with
-      [a, b, c] => [c, b, a]
-    end.
-  
   Theorem hyps_implies_ziel : refute (TS.add (sym_triangle ziel) hyps) = true -> δ ziel.
   Proof.
     intro H.


### PR DESCRIPTION
This modifies the development in hulls.v so that the injection function used to index the points in the plane only has to be injective for a finite number of indices.

This development has been tested in an example.
